### PR TITLE
Inline不能用x:Uid的解决方案

### DIFF
--- a/BDLauncherCSharp/Extensions/I18NExtension.cs
+++ b/BDLauncherCSharp/Extensions/I18NExtension.cs
@@ -9,11 +9,18 @@ using System.Windows;
 
 namespace BDLauncherCSharp.Extensions
 {
+    /// <summary>
+    /// 全球化扩展
+    /// </summary>
     public static class I18NExtension
     {
         private static IEnumerable<string> names;
         private static ResourceManager resourceManager;
 
+        /// <summary>
+        /// 对应用进行初始化
+        /// </summary>
+        /// <param name="resourceMgr">资源管理</param>
         public static void I18NInitialize(this ResourceManager resourceMgr)
         {
             if (resourceMgr is null) throw new NullReferenceException($"this {nameof(ResourceManager)} is null");
@@ -23,38 +30,62 @@ namespace BDLauncherCSharp.Extensions
                                ?.Cast<DictionaryEntry>()
                                 .Select(item => item.Key as string);
         }
+
+        /// <summary>
+        /// 对控件进行初始化
+        /// </summary>
+        /// <param name="element">控件</param>
         public static void I18NInitialize(this DependencyObject element)
         {
-            if (!(element is UIElement target)) return;
-
+            if (element is null) return;
             // 获取子元素
             foreach (var child in LogicalTreeHelper.GetChildren(element))
                 (child as DependencyObject).I18NInitialize();
 
-            if (string.IsNullOrWhiteSpace(target.Uid)) return;
-
-            foreach (var (name, property)
-                in names.Select(name => (name, prefx: $"{target.Uid}."))
-                                      .Where(i => i.name?.StartsWith(i.prefx) ?? false)
-                                      .Select(i => (i.name, i.name.Substring(i.prefx.Length))))
+            if (element is UIElement target)
             {
-                var propertyInfo = element.GetType().GetProperty(property);
-                var str = resourceManager.GetString(name);
-                if (propertyInfo is null || string.IsNullOrWhiteSpace(str)) continue;
-                var constructor = propertyInfo.PropertyType.GetConstructor(new[] { typeof(string) });
-                var method = propertyInfo.PropertyType.GetMethod("Parse", BindingFlags.Static | BindingFlags.Public,
-                                                             null, new[] { typeof(string) }, null);
+                if (string.IsNullOrWhiteSpace(target.Uid)) return;
 
-                propertyInfo.SetValue(element, propertyInfo.PropertyType == typeof(string)
-                                               ? str
-                                               : constructor is null
-                                                   ? method is null
-                                                         ? str
-                                                         : method.Invoke(null, new object[] { str })
-                                                   : constructor.Invoke(new object[] { str }));
+                foreach (var (name, property)
+                    in names.Select(name => (name, prefx: $"{target.Uid}."))
+                                          .Where(i => i.name?.StartsWith(i.prefx) ?? false)
+                                          .Select(i => (i.name, i.name.Substring(i.prefx.Length))))
+                {
+                    var propertyInfo = element.GetType().GetProperty(property);
+
+                    var i18nStr = I18N(name);
+
+                    if (propertyInfo is null || string.IsNullOrWhiteSpace(i18nStr)) continue;
+
+
+                    if (propertyInfo.PropertyType == typeof(string))
+                        propertyInfo.SetValue(element, i18nStr);
+                    else
+                    {
+                        var constructor = propertyInfo.PropertyType.GetConstructor(new[] { typeof(string) });
+                        if (constructor is ConstructorInfo)
+                            propertyInfo.SetValue(element, constructor.Invoke(new object[] { i18nStr }));
+                        else
+                        {
+                            var method = propertyInfo.PropertyType.GetMethod("Parse",
+                                BindingFlags.Static | BindingFlags.Public,
+                                null, new[] { typeof(string) }, null);
+
+                            if (method is MethodInfo)
+                                propertyInfo.SetValue(element, method.Invoke(null, new object[] { i18nStr }));
+                            else
+                                propertyInfo.SetValue(element, i18nStr);
+                        }
+                    }
+                }
             }
         }
 
+        /// <summary>
+        /// 获取对应的本地化资源
+        /// </summary>
+        /// <param name="key">资源键</param>
+        /// <returns>本地化字符串</returns>
         public static string I18N(this string key) => resourceManager.GetString(key);
     }
 }

--- a/BDLauncherCSharp/Extensions/L10NExtension.cs
+++ b/BDLauncherCSharp/Extensions/L10NExtension.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Windows.Markup;
+
+namespace BDLauncherCSharp.Extensions
+{
+    /// <summary>
+    /// 本地化资源标记扩展
+    /// </summary>
+    public class L10NExtension : MarkupExtension
+    {
+        /// <summary>
+        /// 本地化资源键
+        /// </summary>
+        public string Key { get; set; }
+
+        /// <summary>
+        /// 空构造方法
+        /// </summary>
+        public L10NExtension() { }
+
+        /// <summary>
+        /// 获取本地化资源
+        /// </summary>
+        /// <param name="key">资源键</param>
+        public L10NExtension(string key) : this() => this.Key = key;
+
+        public override object ProvideValue(IServiceProvider serviceProvider) => this.Key.I18N();
+    }
+}

--- a/BDLauncherCSharp/MainWindow.xaml
+++ b/BDLauncherCSharp/MainWindow.xaml
@@ -4,9 +4,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:input="clr-namespace:System.Windows.Input;assembly=PresentationCore"
+    xmlns:i18n="clr-namespace:BDLauncherCSharp.Extensions"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     Width="656" Height="520"
-    ResizeMode="NoResize" WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
     <Grid>
         <!--  背景 图像笔刷  -->
@@ -27,13 +27,13 @@
         <Image
             Grid.RowSpan="2"
             Width="130" Height="82"
-            Margin="25,88,0,0" HorizontalAlignment="Left"
+            Margin="25 88 0 0" HorizontalAlignment="Left"
             VerticalAlignment="Top"
             Source="Assets/allied.png" Stretch="UniformToFill" />
         <!--  主要文字位置  -->
         <Grid Grid.Row="1" Grid.ColumnSpan="2">
             <!--  左边的文字  -->
-            <StackPanel Margin="119,25,0,22" HorizontalAlignment="Left">
+            <StackPanel Margin="119 25 0 22" HorizontalAlignment="Left">
                 <TextBlock FontSize="18" Foreground="#FFE6E6E6">
                     <Run Text="Operation: Braindead" /><LineBreak />
                     <Run Text="Presented By Caco" />
@@ -43,13 +43,13 @@
             <!--  右边的文字  -->
             <StackPanel
                 Grid.Row="1" Grid.RowSpan="2" Grid.Column="1"
-                Margin="20,0" HorizontalAlignment="Right">
+                Margin="20 0" HorizontalAlignment="Right">
                 <TextBlock
                     HorizontalAlignment="Center"
                     Block.LineHeight="24" Block.TextAlignment="Center"
                     FontSize="16" Foreground="#FF969696">
                     <!--  用一个 TextBlock 节省内存  -->
-                    <Run Text="Launcher Created By:" /><LineBreak />
+                    <Run Text="{i18n:L10N txtAppAuthor}" /><LineBreak /><!--Launcher Created By:-->
                     <Run Text="Caco" /><LineBreak />
                     <Run Text="=Star=" /><LineBreak />
                     <Run Text="frg2089" /><LineBreak />
@@ -63,7 +63,7 @@
         <!--  可交互的控件位置  -->
         <Grid
             Grid.Row="1" Grid.ColumnSpan="2"
-            Margin="30,278,30,5">
+            Margin="30 278 30 5">
             <Grid.RowDefinitions>
                 <RowDefinition Height="auto" />
                 <RowDefinition Height="auto" />
@@ -72,44 +72,45 @@
             <!--  第一行  -->
             <StackPanel
                 Height="15"
-                Margin="10,3" HorizontalAlignment="Right"
+                Margin="10 3" HorizontalAlignment="Right"
                 Orientation="Horizontal">
-                <CheckBox x:Uid="cbLog" Name="Debug_Check"
+                <CheckBox x:Uid="cbLog"
+                    Name="Debug_Check"
                     Foreground="#FFE6E6E6" IsChecked="True" />
                 <CheckBox x:Name="Admin_Check" x:Uid="cbRunAs"
-                    Margin="10,0"
+                    Margin="10 0"
                     Foreground="#FFE6E6E6" />
             </StackPanel>
             <!--  第二行  -->
-            <DockPanel Grid.Row="1" Margin="10,5">
+            <DockPanel Grid.Row="1" Margin="10 5">
                 <DockPanel.Resources>
                     <Style TargetType="TextBlock">
                         <Setter Property="Foreground" Value="White" />
                     </Style>
                 </DockPanel.Resources>
                 <TextBlock x:Uid="txtCommandLineTip"
-                    Margin="5,0" VerticalAlignment="Center" />
+                    Margin="5 0" VerticalAlignment="Center" />
                 <TextBox x:Name="TB_Command"
-                    Margin="5,0" VerticalContentAlignment="Center"
+                    Margin="5 0" VerticalContentAlignment="Center"
                     input:InputMethod.IsInputMethodEnabled="False" />
             </DockPanel>
             <!--  第三行  -->
             <StackPanel
                 Grid.Row="2"
                 Height="28"
-                Margin="14,5" HorizontalAlignment="Right"
+                Margin="14 5" HorizontalAlignment="Right"
                 Orientation="Horizontal">
                 <Button x:Uid="btnSettings"
-                    Margin="3,0" Padding="30,0"
+                    Margin="3 0" Padding="30 0"
                     Click="Btn_UserInterface_Click" />
                 <Button x:Uid="btnArchive"
-                    Margin="3,0" Padding="30,0"
+                    Margin="3 0" Padding="30 0"
                     Click="Btn_ArchiveLoader_Click" />
                 <Button x:Uid="btnCmdClr"
-                    Margin="3,0" Padding="13,0"
+                    Margin="3 0" Padding="13 0"
                     Click="Btn_CommandClear_Click" />
                 <Button x:Uid="btnRun"
-                    Margin="3,0" Padding="16,0"
+                    Margin="3 0" Padding="16 0"
                     Click="Btn_GameStart_Click" />
             </StackPanel>
         </Grid>

--- a/BDLauncherCSharp/MultilingualResources/BDLauncherCSharp.qps-ploc.xlf
+++ b/BDLauncherCSharp/MultilingualResources/BDLauncherCSharp.qps-ploc.xlf
@@ -106,6 +106,10 @@
           <source>Cancel</source>
           <target state="translated">Cancel</target>
         </trans-unit>
+        <trans-unit id="txtAppAuthor" translate="yes" xml:space="preserve">
+          <source>Launcher Created By:</source>
+          <target state="new">Launcher Created By:</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/BDLauncherCSharp/MultilingualResources/BDLauncherCSharp.zh-Hans.xlf
+++ b/BDLauncherCSharp/MultilingualResources/BDLauncherCSharp.zh-Hans.xlf
@@ -106,6 +106,10 @@
           <source>Cancel</source>
           <target state="translated">取消</target>
         </trans-unit>
+        <trans-unit id="txtAppAuthor" translate="yes" xml:space="preserve">
+          <source>Launcher Created By:</source>
+          <target state="translated">游戏启动前贡献者:</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/BDLauncherCSharp/String/Resource.Designer.cs
+++ b/BDLauncherCSharp/String/Resource.Designer.cs
@@ -241,6 +241,15 @@ namespace BDLauncherCSharp.String {
         }
         
         /// <summary>
+        ///   查找类似 Launcher Created By: 的本地化字符串。
+        /// </summary>
+        public static string txtAppAuthor {
+            get {
+                return ResourceManager.GetString("txtAppAuthor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Command line arguments:  的本地化字符串。
         /// </summary>
         public static string txtCommandLineTip_Text {

--- a/BDLauncherCSharp/String/Resource.resx
+++ b/BDLauncherCSharp/String/Resource.resx
@@ -177,6 +177,9 @@
   <data name="Normal" xml:space="preserve">
     <value>Normal</value>
   </data>
+  <data name="txtAppAuthor" xml:space="preserve">
+    <value>Launcher Created By:</value>
+  </data>
   <data name="txtCommandLineTip.Text" xml:space="preserve">
     <value>Command line arguments: </value>
   </data>

--- a/BDLauncherCSharp/String/Resource.zh-Hans.resx
+++ b/BDLauncherCSharp/String/Resource.zh-Hans.resx
@@ -87,4 +87,7 @@
   <data name="dlgSetting.CloseButtonContent" xml:space="preserve">
     <value>取消</value>
   </data>
+  <data name="txtAppAuthor" xml:space="preserve">
+    <value>游戏启动前贡献者:</value>
+  </data>
 </root>


### PR DESCRIPTION
定义了一个用来l10n的标记扩展
使用方法:

0. 声明名称空间
```xaml
<Element
    ...
    xmlns:i18n="clr-namespace:BDLauncherCSharp.Extensions"
    ...
    >
    ...
</Element>
```
1. 使用
```xaml
<Element Property="{i18n:L10N Key}" />
```

T. ~~不嫌麻烦还可以试试这样写~~
```xaml
<Element Property="{i18n:L10N Key}" xmlns:i18n="clr-namespace:BDLauncherCSharp.Extensions"/>
```